### PR TITLE
Tin 87 transactions

### DIFF
--- a/documents/scripts/DML_tinytitletinder.sql
+++ b/documents/scripts/DML_tinytitletinder.sql
@@ -79,10 +79,10 @@ INSERT INTO parent (age, gender, first_name, last_name, fk_address_id) VALUES
 (32, 'Male', 'Wei', 'Wang',4);
 
 INSERT INTO user (email, password, user_active, created_at, last_login, fk_parent_id) VALUES
-('user1@example.com', 'password1', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 YEAR, 1),
-('user2@example.com', 'password2', 1, '2016-11-05 14:29:36', NOW() - INTERVAL 1 MONTH, 2),
-('user3@example.com', 'password3', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 WEEK, 3),
-('user4@example.com', 'password4', 1, '2019-11-05 14:29:36', NOW() - INTERVAL 1 DAY, 4);
+('user1@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 YEAR, 1),
+('user2@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2016-11-05 14:29:36', NOW() - INTERVAL 1 MONTH, 2),
+('user3@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 WEEK, 3),
+('user4@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2019-11-05 14:29:36', NOW() - INTERVAL 1 DAY, 4);
 
 INSERT INTO role (title) VALUES
 ('Super Admin'),

--- a/documents/scripts/DML_tinytitletinder.sql
+++ b/documents/scripts/DML_tinytitletinder.sql
@@ -20,7 +20,45 @@ INSERT INTO name_suggest (name_suggest_name, gender, popularity, name_days, name
 ('Hans', 'Male', 0.31, '01-01-2023', 'Hans Pilgaard'),
 ('Hansi', 'Male', 0.31, '01-01-2023', 'Hans Pilgaard'),
 ('Margot', 'Female', 0.14, '01-01-2023', 'Margot Robbie'),
-('Maria', 'Female', 0.73, '01-01-2023', 'Maria Bello');
+('Maria', 'Female', 0.73, '01-01-2023', 'Maria Bello'),
+('Zane', 'Male', 0.42, '01-01-2023', 'Zane Grey'),
+('Zara', 'Female', 0.67, '01-01-2023', 'Zara Larsson'),
+('Alice', 'Female', 0.95, '01-01-2023', 'Alice Walker'),
+('Bob', 'Male', 0.88, '01-01-2023', 'Bob Marley'),
+('Elena', 'Female', 0.75, '01-01-2023', 'Elena Kagan'),
+('Oliver', 'Male', 0.89, '01-01-2023', 'Oliver Twist'),
+('Olivia', 'Female', 0.93, '01-01-2023', 'Olivia Wilde'),
+('Samuel', 'Male', 0.76, '01-01-2023', 'Samuel L. Jackson'),
+('Samantha', 'Female', 0.82, '01-01-2023', 'Samantha Smith'),
+('Isaac', 'Male', 0.68, '01-01-2023', 'Isaac Newton'),
+('Isabella', 'Female', 0.91, '01-01-2023', 'Isabella Rossellini'),
+('Nathan', 'Male', 0.77, '01-01-2023', 'Nathan Hale'),
+('Natalie', 'Female', 0.84, '01-01-2023', 'Natalie Portman'),
+('Elijah', 'Male', 0.79, '01-01-2023', 'Elijah Wood'),
+('Eva', 'Female', 0.71, '01-01-2023', 'Eva Mendes'),
+('Oscar', 'Male', 0.65, '01-01-2023', 'Oscar Wilde'),
+('Octavia', 'Female', 0.63, '01-01-2023', 'Octavia Butler'),
+('Victor', 'Male', 0.74, '01-01-2023', 'Victor Hugo'),
+('Victoria', 'Female', 0.88, '01-01-2023', 'Victoria Beckham'),
+('Leo', 'Male', 0.82, '01-01-2023', 'Leonardo DiCaprio'),
+('Leah', 'Female', 0.76, '01-01-2023', 'Leah Remini'),
+('Xavier', 'Male', 0.47, '01-01-2023', 'Xavier Naidoo'),
+('Xena', 'Female', 0.59, '01-01-2023', 'Xena: Warrior Princess'),
+('Quincy', 'Male', 0.61, '01-01-2023', 'Quincy Jones'),
+('Quinn', 'Female', 0.55, '01-01-2023', 'Quinn Shephard'),
+('Jordan', 'Unisex', 0.78, '01-01-2023', 'Michael Jordan'),
+('Taylor', 'Unisex', 0.81, '01-01-2023', 'Taylor Swift'),
+('Alex', 'Unisex', 0.75, '01-01-2023', 'Alex Rodriguez'),
+('Casey', 'Unisex', 0.69, '01-01-2023', 'Casey Affleck'),
+('Cameron', 'Unisex', 0.68, '01-01-2023', 'Cameron Diaz'),
+('Riley', 'Unisex', 0.76, '01-01-2023', 'Riley Keough'),
+('Morgan', 'Unisex', 0.73, '01-01-2023', 'Morgan Freeman'),
+('Avery', 'Unisex', 0.79, '01-01-2023', 'Avery Brooks'),
+('Charlie', 'Unisex', 0.85, '01-01-2023', 'Charlie Chaplin'),
+('Alexis', 'Unisex', 0.77, '01-01-2023', 'Alexis Bledel'),
+('Blake', 'Unisex', 0.82, '01-01-2023', 'Blake Lively'),
+('Dakota', 'Unisex', 0.74, '01-01-2023', 'Dakota Fanning'),
+('Jamie', 'Unisex', 0.80, '01-01-2023', 'Jamie Foxx');
 
 INSERT INTO location (country) VALUES
 ('United States'),
@@ -41,10 +79,10 @@ INSERT INTO parent (age, gender, first_name, last_name, fk_address_id) VALUES
 (32, 'Male', 'Wei', 'Wang',4);
 
 INSERT INTO user (email, password, user_active, created_at, last_login, fk_parent_id) VALUES
-('user1@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 YEAR, 1),
-('user2@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2016-11-05 14:29:36', NOW() - INTERVAL 1 MONTH, 2),
-('user3@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 WEEK, 3),
-('user4@example.com', '$2b$10$7cCi2z1vHM/./DHuK0TpWejNnFaNOJ5ZrXbIMfilP4gyBW1fA/xJm', 1, '2019-11-05 14:29:36', NOW() - INTERVAL 1 DAY, 4);
+('user1@example.com', 'password1', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 YEAR, 1),
+('user2@example.com', 'password2', 1, '2016-11-05 14:29:36', NOW() - INTERVAL 1 MONTH, 2),
+('user3@example.com', 'password3', 1, '2012-11-05 14:29:36', NOW() - INTERVAL 1 WEEK, 3),
+('user4@example.com', 'password4', 1, '2019-11-05 14:29:36', NOW() - INTERVAL 1 DAY, 4);
 
 INSERT INTO role (title) VALUES
 ('Super Admin'),

--- a/src/Controllers/addressController.ts
+++ b/src/Controllers/addressController.ts
@@ -11,7 +11,7 @@ export const createAddress = async (req: Request, res: Response) => {
         location: req.body.location
     };
     const response = await addressService.createAddress(addressRequestDTO);
-    responseController.response(res, response, 200);
+    responseController.response(res, response, 201);
 };
 
 export const getAllAddresses = async (req: Request, res: Response) => {

--- a/src/Controllers/definitionController.ts
+++ b/src/Controllers/definitionController.ts
@@ -8,7 +8,7 @@ export const createDefinition = async (req: Request, res: Response) => {
 		meaning: req.body.meaning
 	};
 	const response = await definitionService.createDefinition(definitionRequestDTO);
-	responseController.response(res, response, 200);
+	responseController.response(res, response, 201);
 };
 
 export const getDefinitionByID = async (req: Request, res: Response) => {

--- a/src/Controllers/familyController.ts
+++ b/src/Controllers/familyController.ts
@@ -10,7 +10,7 @@ export const createFamily = async (req: Request, res: Response) => {
     };
 
     const response = await familyService.createFamily(familyRequestDTO);
-    responseController.response(res, response, 200);
+    responseController.response(res, response, 201);
 };
 
 export const getAllFamilies = async (req: Request, res: Response) => {

--- a/src/Controllers/locationController.ts
+++ b/src/Controllers/locationController.ts
@@ -9,7 +9,7 @@ export const createLocation = async (req: Request, res: Response) => {
     };
 
     const response = await locationService.createLocation(locationRequestDTO);
-    responseController.response(res, response, 200);
+    responseController.response(res, response, 201);
 };
 
 export const getAllLocations = async (req: Request, res: Response) => {

--- a/src/Controllers/nameController.ts
+++ b/src/Controllers/nameController.ts
@@ -21,6 +21,12 @@ export const getNameByID = async (req: Request, res: Response) => {
   responseController.response(res, response, 200);
 };
 
+export const getNameByNameSuggestName = async (req: Request, res: Response) => {
+const response = await nameService.getNameByNameSuggestName(req.params.name);
+responseController.response(res, response, 200);
+};
+
+
 export const getAllNames = async (req: Request, res: Response) => {
   const response = await nameService.getNames();
   responseController.response(res, response, 200);

--- a/src/Controllers/nameController.ts
+++ b/src/Controllers/nameController.ts
@@ -13,7 +13,7 @@ export const createName = async (req: Request, res: Response) => {
   };
 
   const response = await nameService.createName(nameRequestDTO);
-  responseController.response(res, response, 200);
+  responseController.response(res, response, 201);
 };
 
 export const getNameByID = async (req: Request, res: Response) => {

--- a/src/Controllers/originController.ts
+++ b/src/Controllers/originController.ts
@@ -12,7 +12,7 @@ export const createOrigin = async (req: Request, res: Response) => {
     };
 
     const response = await originService.createOrigin(originRequestDTO);
-    responseController.response(res, response, 200);
+    responseController.response(res, response, 201);
 };
 
 export const getOriginByID = async (req: Request, res: Response) => {

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -10,7 +10,8 @@ export const createParent = async (req: Request, res: Response) => {
         gender: req.body.gender,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
-        address: req.body.address
+        families: req.body.families,
+        address: req.body.address,
      };
 
     const response = await parentService.createParent(parentRequestDTO);
@@ -27,6 +28,7 @@ export const getParentById = async (req: Request, res: Response) => {
     responseController.response(res, response, 200);
 };
 
+//TODO: Doesn't work
 export const updateParent = async (req: Request, res: Response) => {
     const parentRequestDTO: ParentRequestDTO = {
         parentId: req.body.id,
@@ -34,6 +36,7 @@ export const updateParent = async (req: Request, res: Response) => {
         gender: req.body.gender,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
+        families: req.body.families,
         address: req.body.address
     };
     const response = await parentService.updateParent(parentRequestDTO);

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -28,17 +28,19 @@ export const getParentById = async (req: Request, res: Response) => {
     responseController.response(res, response, 200);
 };
 
-//TODO: Doesn't work
 export const updateParent = async (req: Request, res: Response) => {
     const parentRequestDTO: ParentRequestDTO = {
-        parentId: req.body.id,
+        parentId: req.body.parentId,
         age: req.body.age,
         gender: req.body.gender,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
+        likedNames: req.body.likedNames,
+        dislikedNames: req.body.dislikedNames,
         families: req.body.families,
         address: req.body.address
     };
+    
     const response = await parentService.updateParent(parentRequestDTO);
     responseController.response(res, response, 200);
 };

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -49,3 +49,8 @@ export const deleteParent = async (req: Request, res: Response) => {
     const response = await parentService.deleteParent(Number(req.params.id));
     responseController.response(res, response, 204);
 };
+
+export const updateTablesForName = async (req: Request, res: Response) => {
+    const response = await parentService.updateTablesForName(Number(req.params.id), req.body.likedNames, req.body.dislikedNames);
+    responseController.response(res, response, 200);
+};

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -4,23 +4,13 @@ import * as responseController from '../Controllers/responseController';
 import { ParentRequestDTO } from '../DTO/parentDTO';
 
 export const createParent = async (req: Request, res: Response) => {
-    let parentRequestDTO: ParentRequestDTO;
-    if (!req.body.user) {
-        parentRequestDTO = {
-            age: req.body.age,
-            gender: req.body.gender,
-            firstName: req.body.firstName,
-            lastName: req.body.lastName,
-            address: req.body.address
-        };
-    }
-     parentRequestDTO = {
+    const parentRequestDTO: ParentRequestDTO = {
         age: req.body.age,
         gender: req.body.gender,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
         address: req.body.address
-    };
+     };
 
     const response = await parentService.createParent(parentRequestDTO);
     responseController.response(res, response, 200);

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -3,6 +3,7 @@ import * as parentService from '../Services/parentService';
 import * as responseController from '../Controllers/responseController';
 import { ParentRequestDTO } from '../DTO/parentDTO';
 
+// TODO: Skal families ikke kunne addes til en parent i create og update?
 export const createParent = async (req: Request, res: Response) => {
     const parentRequestDTO: ParentRequestDTO = {
         age: req.body.age,
@@ -13,7 +14,7 @@ export const createParent = async (req: Request, res: Response) => {
      };
 
     const response = await parentService.createParent(parentRequestDTO);
-    responseController.response(res, response, 200);
+    responseController.response(res, response, 201);
 };
 
 export const getAllParents = async (req: Request, res: Response) => {

--- a/src/Controllers/parentController.ts
+++ b/src/Controllers/parentController.ts
@@ -3,7 +3,6 @@ import * as parentService from '../Services/parentService';
 import * as responseController from '../Controllers/responseController';
 import { ParentRequestDTO } from '../DTO/parentDTO';
 
-// TODO: Skal families ikke kunne addes til en parent i create og update?
 export const createParent = async (req: Request, res: Response) => {
     const parentRequestDTO: ParentRequestDTO = {
         age: req.body.age,

--- a/src/Controllers/roleController.ts
+++ b/src/Controllers/roleController.ts
@@ -8,7 +8,7 @@ export const createRole = async (req: Request, res: Response) => {
         title: req.body.title
     };
 	const response = await roleService.createRole(roleRequestDTO);
-	responseController.response(res, response, 200);
+	responseController.response(res, response, 201);
 };
 
 export const getRoleByID = async (req: Request, res: Response) => {

--- a/src/Controllers/userController.ts
+++ b/src/Controllers/userController.ts
@@ -6,8 +6,7 @@ import { ParentRequestDTO } from '../DTO/parentDTO';
 import { LocationRequestDTO } from '../DTO/locationDTO';
 import { AddressRequestDTO } from '../DTO/addressDTO';
 
-//TODO: Dependency injection eller String med besked om hvilken db
-//TODO: Validering af data, så applikation ikke crasher.
+
 export const createUser = async (req: Request, res: Response) => {
 	const UserRequestDTO: UserRequestDTO = {
 		email: req.body.email,
@@ -19,7 +18,7 @@ export const createUser = async (req: Request, res: Response) => {
 };
 
 export const signUp = async (req: Request, res: Response) => {
-	//TODO: Skal deles op i flere mindre metoder. 
+
 	const locationRequestDTO: LocationRequestDTO = {
 		locationId: req.body.locationId,
 	};

--- a/src/Controllers/userController.ts
+++ b/src/Controllers/userController.ts
@@ -6,8 +6,8 @@ import { ParentRequestDTO } from '../DTO/parentDTO';
 import { LocationRequestDTO } from '../DTO/locationDTO';
 import { AddressRequestDTO } from '../DTO/addressDTO';
 
-//TODO Dependency injection eller String med besked om hvilken db
-//TODO Validering af data, så applikation ikke crasher.
+//TODO: Dependency injection eller String med besked om hvilken db
+//TODO: Validering af data, så applikation ikke crasher.
 export const createUser = async (req: Request, res: Response) => {
 	const UserRequestDTO: UserRequestDTO = {
 		email: req.body.email,
@@ -15,11 +15,11 @@ export const createUser = async (req: Request, res: Response) => {
 		roles: null
 	};
 	const response = await userService.createUser(UserRequestDTO);
-	responseController.response(res, response, 200);
+	responseController.response(res, response, 201);
 };
 
 export const signUp = async (req: Request, res: Response) => {
-	//Skal deles op i flere mindre metoder. 
+	//TODO: Skal deles op i flere mindre metoder. 
 	const locationRequestDTO: LocationRequestDTO = {
 		locationId: req.body.locationId,
 	};

--- a/src/Controllers/userController.ts
+++ b/src/Controllers/userController.ts
@@ -59,7 +59,7 @@ export const getAllUsers = async (req: Request, res: Response) => {
 	responseController.response(res, response, 200);
 };
 
-//TODO Denne kan ikke tage imod rolle uden at opdatere email, crasher appen.
+//TODO: Denne kan ikke tage imod rolle uden at opdatere email, crasher appen.
 export const updateUser = async (req: Request, res: Response) => {
 	const userRequestDTO: UserRequestDTO = {
 		email: req.body.newEmail,

--- a/src/DTO/parentDTO.ts
+++ b/src/DTO/parentDTO.ts
@@ -19,6 +19,8 @@ export interface ParentRequestDTO {
   gender: string;
   firstName: string;
   lastName: string;
+  likedNames?: NameResponseDTO[];
+  dislikedNames?: NameResponseDTO[];
   names?: NameResponseDTO[];
   families?: FamilyResponseDTO[];
   address: AddressRequestDTO;

--- a/src/DTO/parentDTO.ts
+++ b/src/DTO/parentDTO.ts
@@ -7,7 +7,7 @@ export interface ParentResponseDTO {
   gender: string;
   firstName: string;
   lastName: string;
-  names?: NameResponseDTO[];
+  likedNames?: NameResponseDTO[];
   dislikedNames?: NameResponseDTO[];
   families?: FamilyResponseDTO[];
   address: AddressResponseDTO;

--- a/src/DTO/parentDTO.ts
+++ b/src/DTO/parentDTO.ts
@@ -7,8 +7,9 @@ export interface ParentResponseDTO {
   gender: string;
   firstName: string;
   lastName: string;
-  names?: NameResponseDTO[] | null;
-  families: FamilyResponseDTO[];
+  names?: NameResponseDTO[];
+  dislikedNames?: NameResponseDTO[];
+  families?: FamilyResponseDTO[];
   address: AddressResponseDTO;
 }
 
@@ -18,5 +19,7 @@ export interface ParentRequestDTO {
   gender: string;
   firstName: string;
   lastName: string;
+  names?: NameResponseDTO[];
+  families?: FamilyResponseDTO[];
   address: AddressRequestDTO;
 }

--- a/src/Entities/Address.ts
+++ b/src/Entities/Address.ts
@@ -16,7 +16,7 @@ export class Address {
     @Column('varchar', { length: 255, nullable: false, name: 'street' })
     street: string;
 
-    @ManyToOne(() => Location, (location) => location.streets)
+    @ManyToOne(() => Location, (location) => location.addresses)
     @JoinColumn({ name: 'fk_location_id', referencedColumnName: 'locationId' })
     location: Location;
 }

--- a/src/Entities/AuditEntities/AddressADT.ts
+++ b/src/Entities/AuditEntities/AddressADT.ts
@@ -1,17 +1,9 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Address } from '../Address';
-import { JoinColumn, ManyToOne } from 'typeorm';
-import { LocationADT } from './LocationADT';
 
 @AuditingEntity(Address, { name: 'adt_address' })
 export class AddressADT extends Address implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
-    // @ManyToOne(() => LocationADT, (location) => location.streets)
-    // @JoinColumn({ name: 'fk_location_id', referencedColumnName: 'locationId' })
-    // location: LocationADT;
 }

--- a/src/Entities/AuditEntities/AddressADT.ts
+++ b/src/Entities/AuditEntities/AddressADT.ts
@@ -1,6 +1,8 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Address } from '../Address';
-import { ManyToOne } from 'typeorm';
+import { JoinColumn, ManyToOne } from 'typeorm';
 import { LocationADT } from './LocationADT';
 
 @AuditingEntity(Address, { name: 'adt_address' })
@@ -9,6 +11,7 @@ export class AddressADT extends Address implements AuditingEntityDefaultColumns 
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @ManyToOne(() => LocationADT, (location) => location.streets)
-    location: LocationADT;
+    // @ManyToOne(() => LocationADT, (location) => location.streets)
+    // @JoinColumn({ name: 'fk_location_id', referencedColumnName: 'locationId' })
+    // location: LocationADT;
 }

--- a/src/Entities/AuditEntities/DefinitionADT.ts
+++ b/src/Entities/AuditEntities/DefinitionADT.ts
@@ -6,5 +6,4 @@ export class DefinitionADT extends Definition implements AuditingEntityDefaultCo
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
 }

--- a/src/Entities/AuditEntities/FamilyADT.ts
+++ b/src/Entities/AuditEntities/FamilyADT.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Family } from '../Family';
 import { ManyToMany, JoinColumn, JoinTable } from 'typeorm';
@@ -9,18 +11,18 @@ export class FamilyADT extends Family implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @ManyToMany(() => ParentADT, (parent) => parent.families, { nullable: true })
-    @JoinColumn()
-    @JoinTable({
-        name: 'adt_family_parent',
-        joinColumn: {
-            name: 'fk_family_id',
-            referencedColumnName: 'familyId',
-        },
-        inverseJoinColumn: {
-            name: 'fk_parent_id',
-            referencedColumnName: 'parentId',
-        },
-    })
-    parents: ParentADT[];
+    // @ManyToMany(() => ParentADT, (parent) => parent.families, { nullable: true })
+    // @JoinColumn()
+    // @JoinTable({
+    //     name: 'family_parent',
+    //     joinColumn: {
+    //         name: 'fk_family_id',
+    //         referencedColumnName: 'familyId',
+    //     },
+    //     inverseJoinColumn: {
+    //         name: 'fk_parent_id',
+    //         referencedColumnName: 'parentId',
+    //     },
+    // })
+    // parents: ParentADT[] | null;
 }

--- a/src/Entities/AuditEntities/FamilyADT.ts
+++ b/src/Entities/AuditEntities/FamilyADT.ts
@@ -1,28 +1,9 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Family } from '../Family';
-import { ManyToMany, JoinColumn, JoinTable } from 'typeorm';
-import { ParentADT } from './ParentADT';
 
 @AuditingEntity(Family, { name: 'adt_family' })
 export class FamilyADT extends Family implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
-    // @ManyToMany(() => ParentADT, (parent) => parent.families, { nullable: true })
-    // @JoinColumn()
-    // @JoinTable({
-    //     name: 'family_parent',
-    //     joinColumn: {
-    //         name: 'fk_family_id',
-    //         referencedColumnName: 'familyId',
-    //     },
-    //     inverseJoinColumn: {
-    //         name: 'fk_parent_id',
-    //         referencedColumnName: 'parentId',
-    //     },
-    // })
-    // parents: ParentADT[] | null;
 }

--- a/src/Entities/AuditEntities/LocationADT.ts
+++ b/src/Entities/AuditEntities/LocationADT.ts
@@ -1,17 +1,9 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Location } from '../Location';
-import { OneToMany } from 'typeorm';
-import { AddressADT } from './AddressADT';
-import { ParentADT } from './ParentADT';
 
 @AuditingEntity(Location, { name: 'adt_location' })
 export class LocationADT extends Location implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
-    // @OneToMany(() => AddressADT, (address) => address.location)
-    // streets: AddressADT[];
 }

--- a/src/Entities/AuditEntities/LocationADT.ts
+++ b/src/Entities/AuditEntities/LocationADT.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Location } from '../Location';
 import { OneToMany } from 'typeorm';
@@ -10,9 +12,6 @@ export class LocationADT extends Location implements AuditingEntityDefaultColumn
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @OneToMany(() => AddressADT, (address) => address.location)
-    streets: AddressADT[];
-
-    @OneToMany(() => ParentADT, (parents) => parents.location)
-    parents: ParentADT[];
+    // @OneToMany(() => AddressADT, (address) => address.location)
+    // streets: AddressADT[];
 }

--- a/src/Entities/AuditEntities/NameADT.ts
+++ b/src/Entities/AuditEntities/NameADT.ts
@@ -1,8 +1,11 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // TODO: Update modifiedBy column to log user who made changes
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Name } from '../Name';
-import { ManyToMany, JoinTable, Column } from 'typeorm';
+import { ManyToMany, JoinTable, Column, JoinColumn } from 'typeorm';
 import { OriginADT } from './OriginADT';
+import { ParentADT } from './ParentADT';
 
 @AuditingEntity(Name, { name: 'adt_name' })
 export class NameADT extends Name implements AuditingEntityDefaultColumns {
@@ -10,19 +13,28 @@ export class NameADT extends Name implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @ManyToMany(() => OriginADT, (origin) => origin.names, { nullable: true })
-    @JoinTable({
-        name: 'adt_name_suggest_origin',
-        joinColumn: {
-            name: 'fk_name_suggest_id',
-            referencedColumnName: 'nameSuggestId',
-        },
-        inverseJoinColumn: {
-            name: 'fk_origin_id',
-            referencedColumnName: 'originId',
-        },
-    })
-    origins: OriginADT[] | null;
+    // @ManyToMany(() => OriginADT, (origin) => origin.names, { nullable: true })
+    // @JoinColumn()
+    // @JoinTable({
+    //     name: 'name_suggest_origin',
+    //     joinColumn: {
+    //         name: 'fk_name_suggest_id',
+    //         referencedColumnName: 'nameSuggestId',
+    //     },
+    //     inverseJoinColumn: {
+    //         name: 'fk_origin_id',
+    //         referencedColumnName: 'originId',
+    //     },
+    // })
+    // origins: OriginADT[] | null;
+
+    // @ManyToMany(() => ParentADT, (parent) => parent.names)
+    // @JoinColumn()
+    // parents: ParentADT[];
+
+    // @ManyToMany(() => ParentADT, (parent) => parent.names)
+    // @JoinColumn()
+    // parentsDislike: ParentADT[];
 
     @Column('varchar', { length: 255, name: 'modified_by', nullable: true })
     modifiedBy: string;

--- a/src/Entities/AuditEntities/NameADT.ts
+++ b/src/Entities/AuditEntities/NameADT.ts
@@ -1,40 +1,13 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // TODO: Update modifiedBy column to log user who made changes
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Name } from '../Name';
-import { ManyToMany, JoinTable, Column, JoinColumn } from 'typeorm';
-import { OriginADT } from './OriginADT';
-import { ParentADT } from './ParentADT';
+import { Column } from 'typeorm';
 
 @AuditingEntity(Name, { name: 'adt_name' })
 export class NameADT extends Name implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
-    // @ManyToMany(() => OriginADT, (origin) => origin.names, { nullable: true })
-    // @JoinColumn()
-    // @JoinTable({
-    //     name: 'name_suggest_origin',
-    //     joinColumn: {
-    //         name: 'fk_name_suggest_id',
-    //         referencedColumnName: 'nameSuggestId',
-    //     },
-    //     inverseJoinColumn: {
-    //         name: 'fk_origin_id',
-    //         referencedColumnName: 'originId',
-    //     },
-    // })
-    // origins: OriginADT[] | null;
-
-    // @ManyToMany(() => ParentADT, (parent) => parent.names)
-    // @JoinColumn()
-    // parents: ParentADT[];
-
-    // @ManyToMany(() => ParentADT, (parent) => parent.names)
-    // @JoinColumn()
-    // parentsDislike: ParentADT[];
 
     @Column('varchar', { length: 255, name: 'modified_by', nullable: true })
     modifiedBy: string;

--- a/src/Entities/AuditEntities/OriginADT.ts
+++ b/src/Entities/AuditEntities/OriginADT.ts
@@ -1,7 +1,10 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Origin } from '../Origin';
-import { ManyToMany, JoinColumn } from 'typeorm';
+import { ManyToMany, JoinColumn, OneToOne } from 'typeorm';
 import { NameADT } from './NameADT';
+import { DefinitionADT } from './DefinitionADT';
 
 @AuditingEntity(Origin, { name: 'adt_origin' })
 export class OriginADT extends Origin implements AuditingEntityDefaultColumns {
@@ -9,8 +12,11 @@ export class OriginADT extends Origin implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @ManyToMany(() => NameADT, (name) => name.origins, { nullable: true })
-    @JoinColumn()
-    names: NameADT[];
+    // @ManyToMany(() => NameADT, (name) => name.origins)
+    // @JoinColumn()
+    // names: NameADT[];
+
+    // @OneToOne(() => DefinitionADT)
+    // definition: DefinitionADT;
 
 }

--- a/src/Entities/AuditEntities/OriginADT.ts
+++ b/src/Entities/AuditEntities/OriginADT.ts
@@ -1,10 +1,7 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Origin } from '../Origin';
-import { ManyToMany, JoinColumn, OneToOne } from 'typeorm';
-import { NameADT } from './NameADT';
-import { DefinitionADT } from './DefinitionADT';
+import { BeforeInsert } from 'typeorm';
+import { appDataSource } from '../../Repositories/data-source';
 
 @AuditingEntity(Origin, { name: 'adt_origin' })
 export class OriginADT extends Origin implements AuditingEntityDefaultColumns {
@@ -12,11 +9,11 @@ export class OriginADT extends Origin implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    // @ManyToMany(() => NameADT, (name) => name.origins)
-    // @JoinColumn()
-    // names: NameADT[];
-
-    // @OneToOne(() => DefinitionADT)
-    // definition: DefinitionADT;
-
+    @BeforeInsert()
+    dropFkParentId() {
+        const queryRunner = appDataSource.createQueryRunner();
+        queryRunner.query('ALTER TABLE adt_origin DROP COLUMN fk_definition_id;');
+        queryRunner.query('ALTER TABLE adt_origin ADD COLUMN fk_definition_id INT NULL;');
+        queryRunner.release();
+    }
 }

--- a/src/Entities/AuditEntities/OriginADT.ts
+++ b/src/Entities/AuditEntities/OriginADT.ts
@@ -10,10 +10,12 @@ export class OriginADT extends Origin implements AuditingEntityDefaultColumns {
     readonly _modifiedAt!: Date;
 
     @BeforeInsert()
-    dropFkParentId() {
-        const queryRunner = appDataSource.createQueryRunner();
-        queryRunner.query('ALTER TABLE adt_origin DROP COLUMN fk_definition_id;');
-        queryRunner.query('ALTER TABLE adt_origin ADD COLUMN fk_definition_id INT NULL;');
-        queryRunner.release();
+    dropFkOriginId() {
+        if (process.env.SYNCHRONIZE === 'true') {
+            const queryRunner = appDataSource.createQueryRunner();
+            queryRunner.query('ALTER TABLE adt_origin DROP COLUMN fk_definition_id;');
+            queryRunner.query('ALTER TABLE adt_origin ADD COLUMN fk_definition_id INT NULL;');
+            queryRunner.release();
+        }
     }
 }

--- a/src/Entities/AuditEntities/ParentADT.ts
+++ b/src/Entities/AuditEntities/ParentADT.ts
@@ -8,12 +8,14 @@ export class ParentADT extends Parent implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-    
+
     @BeforeInsert()
-    dropFkParentId() {
-        const queryRunner = appDataSource.createQueryRunner();
-        queryRunner.query('ALTER TABLE adt_parent DROP COLUMN fk_address_id;');
-        queryRunner.query('ALTER TABLE adt_parent ADD COLUMN fk_address_id INT NULL;');
-        queryRunner.release();
+    dropFkAddressId() {
+        if (process.env.SYNCHRONIZE !== 'true') {
+            const queryRunner = appDataSource.createQueryRunner();
+            queryRunner.query('ALTER TABLE adt_parent DROP COLUMN fk_address_id;');
+            queryRunner.query('ALTER TABLE adt_parent ADD COLUMN fk_address_id INT NULL;');
+            queryRunner.release();
+        }
     }
 }

--- a/src/Entities/AuditEntities/ParentADT.ts
+++ b/src/Entities/AuditEntities/ParentADT.ts
@@ -1,53 +1,19 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Parent } from '../Parent';
-import { OneToOne, JoinColumn, ManyToMany, JoinTable, Column, BeforeInsert } from 'typeorm';
-import { NameADT } from './NameADT';
-import { FamilyADT } from './FamilyADT';
-import { AddressADT } from './AddressADT';
+import { BeforeInsert } from 'typeorm';
+import { appDataSource } from '../../Repositories/data-source';
 
 @AuditingEntity(Parent, { name: 'adt_parent' })
 export class ParentADT extends Parent implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
-
-    // @ManyToMany(() => NameADT, (name) => name.parents, { nullable: true })
-    // @JoinColumn()
-    // @JoinTable({
-    //     name: 'parent_name_suggest',
-    //     joinColumn: {
-    //         name: 'fk_parent_id',
-    //         referencedColumnName: 'parentId',
-    //     },
-    //     inverseJoinColumn: {
-    //         name: 'fk_name_suggest_id',
-    //         referencedColumnName: 'nameSuggestId',
-    //     },
-    // })
-    // names: NameADT[] | null;
-
-    // @ManyToMany(() => NameADT, (name) => name.parents, { nullable: true })
-    // @JoinColumn()
-    // @JoinTable({
-    //     name: 'parent_name_suggest_dislike',
-    //     joinColumn: {
-    //         name: 'fk_parent_id',
-    //         referencedColumnName: 'parentId',
-    //     },
-    //     inverseJoinColumn: {
-    //         name: 'fk_name_suggest_id',
-    //         referencedColumnName: 'nameSuggestId',
-    //     },
-    // })
-    // namesDisliked: NameADT[] | null;
-
-    // @ManyToMany(() => FamilyADT, (family) => family.parents)
-    // families: FamilyADT[];
-
-    // @OneToOne(() => AddressADT)
-    // @JoinColumn({ name: 'fk_address_id' })
-    // address: AddressADT;
-
+    
+    @BeforeInsert()
+    dropFkParentId() {
+        const queryRunner = appDataSource.createQueryRunner();
+        queryRunner.query('ALTER TABLE adt_parent DROP COLUMN fk_address_id;');
+        queryRunner.query('ALTER TABLE adt_parent ADD COLUMN fk_address_id INT NULL;');
+        queryRunner.release();
+    }
 }

--- a/src/Entities/AuditEntities/ParentADT.ts
+++ b/src/Entities/AuditEntities/ParentADT.ts
@@ -1,10 +1,11 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Parent } from '../Parent';
-import { OneToOne, JoinColumn, ManyToMany, JoinTable, ManyToOne } from 'typeorm';
-import { UserADT } from './UserADT';
+import { OneToOne, JoinColumn, ManyToMany, JoinTable, Column, BeforeInsert } from 'typeorm';
 import { NameADT } from './NameADT';
 import { FamilyADT } from './FamilyADT';
-import { LocationADT } from './LocationADT';
+import { AddressADT } from './AddressADT';
 
 @AuditingEntity(Parent, { name: 'adt_parent' })
 export class ParentADT extends Parent implements AuditingEntityDefaultColumns {
@@ -12,29 +13,41 @@ export class ParentADT extends Parent implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @OneToOne(() => UserADT)
-    @JoinColumn()
-    user: UserADT;
+    // @ManyToMany(() => NameADT, (name) => name.parents, { nullable: true })
+    // @JoinColumn()
+    // @JoinTable({
+    //     name: 'parent_name_suggest',
+    //     joinColumn: {
+    //         name: 'fk_parent_id',
+    //         referencedColumnName: 'parentId',
+    //     },
+    //     inverseJoinColumn: {
+    //         name: 'fk_name_suggest_id',
+    //         referencedColumnName: 'nameSuggestId',
+    //     },
+    // })
+    // names: NameADT[] | null;
 
-    @ManyToMany(() => NameADT, (name) => name.parents, { nullable: true })
-    @JoinColumn()
-    @JoinTable({
-        name: 'adt_parent_name_suggest',
-        joinColumn: {
-            name: 'fk_parent_id',
-            referencedColumnName: 'parentId',
-        },
-        inverseJoinColumn: {
-            name: 'fk_name_suggest_id',
-            referencedColumnName: 'nameSuggestId',
-        },
-    })
-    names: NameADT[];
+    // @ManyToMany(() => NameADT, (name) => name.parents, { nullable: true })
+    // @JoinColumn()
+    // @JoinTable({
+    //     name: 'parent_name_suggest_dislike',
+    //     joinColumn: {
+    //         name: 'fk_parent_id',
+    //         referencedColumnName: 'parentId',
+    //     },
+    //     inverseJoinColumn: {
+    //         name: 'fk_name_suggest_id',
+    //         referencedColumnName: 'nameSuggestId',
+    //     },
+    // })
+    // namesDisliked: NameADT[] | null;
 
-    @ManyToMany(() => FamilyADT, (family) => family.parents)
-    families: FamilyADT[];
+    // @ManyToMany(() => FamilyADT, (family) => family.parents)
+    // families: FamilyADT[];
 
-    @ManyToOne(() => LocationADT, (location) => location.parents)
-    location: LocationADT;
+    // @OneToOne(() => AddressADT)
+    // @JoinColumn({ name: 'fk_address_id' })
+    // address: AddressADT;
 
 }

--- a/src/Entities/AuditEntities/RoleADT.ts
+++ b/src/Entities/AuditEntities/RoleADT.ts
@@ -1,9 +1,15 @@
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Role } from '../Role';
+import { UserADT } from './UserADT';
+import { ManyToMany, JoinColumn } from 'typeorm';
 
 @AuditingEntity(Role, { name: 'adt_role' })
 export class RoleADT extends Role implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction.Update;
     readonly _modifiedAt!: Date;
+
+    @ManyToMany(()=> UserADT, (user) => user.roles)
+    @JoinColumn()
+    users: UserADT[];
 }

--- a/src/Entities/AuditEntities/RoleADT.ts
+++ b/src/Entities/AuditEntities/RoleADT.ts
@@ -1,18 +1,9 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Role } from '../Role';
-import { JoinColumn, ManyToMany } from 'typeorm';
-import { UserADT } from './UserADT';
 
 @AuditingEntity(Role, { name: 'adt_role' })
 export class RoleADT extends Role implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction.Update;
     readonly _modifiedAt!: Date;
-
-    // @ManyToMany(() => UserADT, (user) => user.roles)
-    // @JoinColumn()
-    // users: UserADT[];
-
 }

--- a/src/Entities/AuditEntities/RoleADT.ts
+++ b/src/Entities/AuditEntities/RoleADT.ts
@@ -1,6 +1,8 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { Role } from '../Role';
-import { ManyToMany } from 'typeorm';
+import { JoinColumn, ManyToMany } from 'typeorm';
 import { UserADT } from './UserADT';
 
 @AuditingEntity(Role, { name: 'adt_role' })
@@ -9,7 +11,8 @@ export class RoleADT extends Role implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction.Update;
     readonly _modifiedAt!: Date;
 
-    @ManyToMany(() => UserADT, (user) => user.roles)
-    users: UserADT[];
+    // @ManyToMany(() => UserADT, (user) => user.roles)
+    // @JoinColumn()
+    // users: UserADT[];
 
 }

--- a/src/Entities/AuditEntities/UserADT.ts
+++ b/src/Entities/AuditEntities/UserADT.ts
@@ -12,10 +12,12 @@ export class UserADT extends User implements AuditingEntityDefaultColumns {
 
     @BeforeInsert()
     dropFkParentId() {
-        const queryRunner = appDataSource.createQueryRunner();
-        queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
-        queryRunner.query('ALTER TABLE adt_user ADD COLUMN fk_parent_id INT NULL;');
-        queryRunner.release();
+        if (process.env.SYNCHRONIZE === 'true') {
+            const queryRunner = appDataSource.createQueryRunner();
+            queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
+            queryRunner.query('ALTER TABLE adt_user ADD COLUMN fk_parent_id INT NULL;');
+            queryRunner.release();
+        }
     }
 
     @Column('varchar', { length: 255, name: 'modified_by', nullable: true })

--- a/src/Entities/AuditEntities/UserADT.ts
+++ b/src/Entities/AuditEntities/UserADT.ts
@@ -1,14 +1,30 @@
 // TODO: Update modifiedBy column to log user who made changes
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { User } from '../User';
-import { Column, BeforeInsert } from 'typeorm';
+import { Column, BeforeInsert, JoinColumn, JoinTable, ManyToMany } from 'typeorm';
 import { appDataSource } from '../../Repositories/data-source';
+import { RoleADT } from './RoleADT';
 
 @AuditingEntity(User, { name: 'adt_user' })
 export class UserADT extends User implements AuditingEntityDefaultColumns {
     readonly _seq!: number;
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
+
+    @ManyToMany(() => RoleADT, (role) => role.users, { nullable: true })
+    @JoinColumn()
+    @JoinTable({
+        name: 'adt_user_role',
+        joinColumn: {
+            name: 'fk_user_id',
+            referencedColumnName: 'userId'
+        },
+        inverseJoinColumn: {
+            name: 'fk_role_id',
+            referencedColumnName: 'roleId'
+        }
+    })
+    roles: RoleADT[] | null;
 
     @BeforeInsert()
     dropFkParentId() {

--- a/src/Entities/AuditEntities/UserADT.ts
+++ b/src/Entities/AuditEntities/UserADT.ts
@@ -1,8 +1,12 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // TODO: Update modifiedBy column to log user who made changes
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { User } from '../User';
-import { ManyToMany, JoinTable, Column } from 'typeorm';
+import { ManyToMany, JoinTable, Column, JoinColumn, OneToOne, BeforeInsert, AfterLoad, AfterInsert, AfterUpdate, BeforeUpdate } from 'typeorm';
 import { RoleADT } from './RoleADT';
+import { ParentADT } from './ParentADT';
+import { appDataSource } from '../../Repositories/data-source';
 
 @AuditingEntity(User, { name: 'adt_user' })
 export class UserADT extends User implements AuditingEntityDefaultColumns {
@@ -10,19 +14,48 @@ export class UserADT extends User implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    @ManyToMany(() => RoleADT, (role) => role.users, { nullable: true })
-    @JoinTable({
-        name: 'adt_user_role',
-        joinColumn: {
-            name: 'fk_user_id',
-            referencedColumnName: 'userId'
-        },
-        inverseJoinColumn: {
-            name: 'fk_role_id',
-            referencedColumnName: 'roleId'
-        }
-    })
-    roles: RoleADT[] | null;
+    // @AfterInsert()
+    // dropFkParentId() {
+    //     const queryRunner = appDataSource.createQueryRunner();
+    //     queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
+    // }
+
+    // @AfterUpdate()
+    // dropFkParentId2() {
+    //     return 'ALTER TABLE adt_user DROP COLUMN fk_parent_id;';
+    // }
+
+    // @BeforeUpdate()
+    // dropFkParentId3() {
+    //     return 'ALTER TABLE adt_user DROP COLUMN fk_parent_id;';
+    // }
+
+    @BeforeInsert()
+    dropFkParentId1() {
+        const queryRunner = appDataSource.createQueryRunner();
+        queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
+        queryRunner.query('ALTER TABLE adt_user ADD COLUMN fk_parent_id INT NULL;');
+        queryRunner.release();
+    }
+
+
+    // @OneToOne(() => ParentADT)
+    // @JoinColumn({ name: 'fk_parent_id' })
+    // parent: ParentADT;
+
+    // @ManyToMany(() => RoleADT, (role) => role.users, { nullable: true })
+    // @JoinTable({
+    //     name: 'adt_user_role',
+    //     joinColumn: {
+    //         name: 'fk_user_id',
+    //         referencedColumnName: 'userId'
+    //     },
+    //     inverseJoinColumn: {
+    //         name: 'fk_role_id',
+    //         referencedColumnName: 'roleId'
+    //     }
+    // })
+    // roles: RoleADT[] | null;
 
     @Column('varchar', { length: 255, name: 'modified_by', nullable: true })
     modifiedBy: string;

--- a/src/Entities/AuditEntities/UserADT.ts
+++ b/src/Entities/AuditEntities/UserADT.ts
@@ -1,11 +1,7 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // TODO: Update modifiedBy column to log user who made changes
 import { AuditingAction, AuditingEntity, AuditingEntityDefaultColumns } from 'typeorm-auditing';
 import { User } from '../User';
-import { ManyToMany, JoinTable, Column, JoinColumn, OneToOne, BeforeInsert, AfterLoad, AfterInsert, AfterUpdate, BeforeUpdate } from 'typeorm';
-import { RoleADT } from './RoleADT';
-import { ParentADT } from './ParentADT';
+import { Column, BeforeInsert } from 'typeorm';
 import { appDataSource } from '../../Repositories/data-source';
 
 @AuditingEntity(User, { name: 'adt_user' })
@@ -14,48 +10,13 @@ export class UserADT extends User implements AuditingEntityDefaultColumns {
     readonly _action!: AuditingAction;
     readonly _modifiedAt!: Date;
 
-    // @AfterInsert()
-    // dropFkParentId() {
-    //     const queryRunner = appDataSource.createQueryRunner();
-    //     queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
-    // }
-
-    // @AfterUpdate()
-    // dropFkParentId2() {
-    //     return 'ALTER TABLE adt_user DROP COLUMN fk_parent_id;';
-    // }
-
-    // @BeforeUpdate()
-    // dropFkParentId3() {
-    //     return 'ALTER TABLE adt_user DROP COLUMN fk_parent_id;';
-    // }
-
     @BeforeInsert()
-    dropFkParentId1() {
+    dropFkParentId() {
         const queryRunner = appDataSource.createQueryRunner();
         queryRunner.query('ALTER TABLE adt_user DROP COLUMN fk_parent_id;');
         queryRunner.query('ALTER TABLE adt_user ADD COLUMN fk_parent_id INT NULL;');
         queryRunner.release();
     }
-
-
-    // @OneToOne(() => ParentADT)
-    // @JoinColumn({ name: 'fk_parent_id' })
-    // parent: ParentADT;
-
-    // @ManyToMany(() => RoleADT, (role) => role.users, { nullable: true })
-    // @JoinTable({
-    //     name: 'adt_user_role',
-    //     joinColumn: {
-    //         name: 'fk_user_id',
-    //         referencedColumnName: 'userId'
-    //     },
-    //     inverseJoinColumn: {
-    //         name: 'fk_role_id',
-    //         referencedColumnName: 'roleId'
-    //     }
-    // })
-    // roles: RoleADT[] | null;
 
     @Column('varchar', { length: 255, name: 'modified_by', nullable: true })
     modifiedBy: string;

--- a/src/Entities/Location.ts
+++ b/src/Entities/Location.ts
@@ -3,13 +3,13 @@ import { Address } from './Address';
 
 @Entity()
 export class Location {
-    
+
     @PrimaryGeneratedColumn({ name: 'location_id' })
     locationId: number;
 
-    @Column('varchar',{ length: 255, nullable: false, name: 'country' })
+    @Column('varchar', { length: 255, nullable: false, name: 'country' })
     country: string;
 
     @OneToMany(() => Address, (address) => address.location)
-    streets: Address[];
+    addresses: Address[];
 }

--- a/src/Entities/Name.ts
+++ b/src/Entities/Name.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   JoinTable,
   ManyToMany,
@@ -15,6 +16,7 @@ export class Name {
   @PrimaryGeneratedColumn({ name: 'name_suggest_id' })
   nameSuggestId: number;
 
+  @Index('name',{ unique: true }) 
   @Column('varchar', { length: 255, nullable: false, name: 'name_suggest_name', unique: true, })
   nameSuggestName: string;
 

--- a/src/Entities/Name.ts
+++ b/src/Entities/Name.ts
@@ -46,11 +46,11 @@ export class Name {
   })
   origins: Origin[] | null;
 
-  @ManyToMany(() => Parent, (parent) => parent.names)
+  @ManyToMany(() => Parent, (parent) => parent.likedNames)
   @JoinColumn()
   parents: Parent[];
 
-  @ManyToMany(() => Parent, (parent) => parent.names)
+  @ManyToMany(() => Parent, (parent) => parent.likedNames)
   @JoinColumn()
   parentsDislike: Parent[];
 }

--- a/src/Entities/Parent.ts
+++ b/src/Entities/Parent.ts
@@ -34,7 +34,7 @@ export class Parent {
       referencedColumnName: 'nameSuggestId',
     },
   })
-  names: Name[] | null;
+  likedNames: Name[] | null;
 
   @ManyToMany(() => Name, (name) => name.parents, { nullable: true })
   @JoinColumn()
@@ -49,7 +49,7 @@ export class Parent {
       referencedColumnName: 'nameSuggestId',
     },
   })
-  namesDisliked: Name[] | null;
+  dislikedNames: Name[] | null;
 
   @ManyToMany(() => Family, (family) => family.parents)
   families: Family[];

--- a/src/Entities/User.ts
+++ b/src/Entities/User.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, JoinColumn, JoinTable, ManyToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, Index, JoinColumn, JoinTable, ManyToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Role } from './Role';
 import { Parent } from './Parent';
 
@@ -9,6 +9,7 @@ export class User {
     userId: number;
 
     @Column('varchar', { length: 255, nullable: false, name: 'email', unique: true })
+    @Index('login',['email'], { unique: true })
     email: string;
 
     @Column('varchar', { length: 255, nullable: false, name: 'password' })

--- a/src/Repositories/locationRepository.ts
+++ b/src/Repositories/locationRepository.ts
@@ -2,10 +2,10 @@ import { Location } from '../Entities/Location';
 import { appDataSource } from './data-source';
 
 export const locationRepo = appDataSource.getRepository(Location).extend({
-    findOneByID(id: number){
+    findOneByID(id: number) {
         return locationRepo.findOne({
             relations: {
-                streets: true
+                addresses: true
             },
             where: {
                 locationId: id
@@ -15,8 +15,8 @@ export const locationRepo = appDataSource.getRepository(Location).extend({
     findAll() {
         return locationRepo.find({
             relations: {
-                streets: true
+                addresses: true
             },
         });
-    }    
+    }
 });

--- a/src/Repositories/nameRepository.ts
+++ b/src/Repositories/nameRepository.ts
@@ -27,18 +27,18 @@ export const nameRepo = appDataSource.getRepository(Name).extend({
   findDislikedNamesByParentId(parentId: number) {
     return nameRepo.query('call GetDislikedNamesOriginsDefinitionsByParentId(?)', [parentId]);
   },
-  findParentlessNames(parentId: number){
+  findParentlessNames(parentId: number) {
     return nameRepo.query('call GetNamesWithNoParentRelation(?)', [parentId]);
   },
   findOneByName(name: string) {
     return nameRepo.findOne({
-relations: {
-  origins: true, 
-  parents: true,
-},
-where: {
-  nameSuggestName: name
-}
+      relations: {
+        origins: true,
+        parents: true,
+      },
+      where: {
+        nameSuggestName: name
+      }
     });
   }
 });

--- a/src/Repositories/nameRepository.ts
+++ b/src/Repositories/nameRepository.ts
@@ -29,5 +29,16 @@ export const nameRepo = appDataSource.getRepository(Name).extend({
   },
   findParentlessNames(parentId: number){
     return nameRepo.query('call GetNamesWithNoParentRelation(?)', [parentId]);
+  },
+  findOneByName(name: string) {
+    return nameRepo.findOne({
+relations: {
+  origins: true, 
+  parents: true,
+},
+where: {
+  nameSuggestName: name
+}
+    });
   }
 });

--- a/src/Repositories/originRepository.ts
+++ b/src/Repositories/originRepository.ts
@@ -6,10 +6,17 @@ export const originRepo = appDataSource.getRepository(Origin).extend({
         return originRepo.findOne({
             where: {
                 originId: id
+            },
+            relations: {
+                definition: true
             }
         });
     },
     findAll() {
-        return originRepo.find();
+        return originRepo.find({
+            relations: {
+                definition: true
+            }
+        });
     }
 });

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -8,6 +8,8 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
                 parentId: id
             },
             relations: {
+                likedNames: true,
+                dislikedNames: true,
                 address: true,
                 families: true
             }

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -1,6 +1,4 @@
-import { Address } from '../Entities/Address';
 import { Parent } from '../Entities/Parent';
-import { User } from '../Entities/User';
 import { appDataSource } from './data-source';
 
 export const parentRepo = appDataSource.getRepository(Parent).extend({
@@ -41,14 +39,4 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
             }
         );
     },
-    signup(parent: Parent, user: User, address: Address) {
-        return parentRepo.manager.transaction(
-            'SERIALIZABLE',
-            async (manager) => {
-                await manager.save(address);
-                await manager.save(parent);
-                await manager.save(user);
-            }
-        );
-    }
 });

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -26,19 +26,16 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
         return parentRepo.manager.transaction(
             'SERIALIZABLE',
             async (manager) => {
-                await Promise.all(likedNames.map(async (nameSuggestId) => {
-                    await manager.query('INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES (?, ?)', [
-                        parentId,
-                        nameSuggestId,
-                    ]);
-                }));
-                await Promise.all(dislikedNames.map(async (nameSuggestId) => {
-                    await manager.query('INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES (?, ?)', [
-                        parentId,
-                        nameSuggestId,
-                    ]);
-                }));
+                if (likedNames.length > 0) {
+                    const likedValues = likedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
+                    await manager.query(`INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES ${likedValues}`);
+                }
+    
+                if (dislikedNames.length > 0) {
+                    const dislikedValues = dislikedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
+                    await manager.query(`INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES ${dislikedValues}`);
+                }
             }
         );
-    }
+    }    
 });

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -1,4 +1,6 @@
+import { Address } from '../Entities/Address';
 import { Parent } from '../Entities/Parent';
+import { User } from '../Entities/User';
 import { appDataSource } from './data-source';
 
 export const parentRepo = appDataSource.getRepository(Parent).extend({
@@ -24,19 +26,29 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
             }
         });
     },
-    updateTablesForName(parentId: number, likedNames: number[], dislikedNames: number[]) {
+    saveLikedDislikedNames(parentId: number, likedNames: number[], dislikedNames: number[]) {
         return parentRepo.manager.transaction(
-            'SERIALIZABLE',
-            async (manager) => {
+            'READ UNCOMMITTED',
+            async (transactionalEntityManager) => {
                 if (likedNames.length > 0) {
                     const likedValues = likedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
-                    await manager.query(`INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES ${likedValues}`);
+                    await transactionalEntityManager.query(`INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES ${likedValues}`);
                 }
                 if (dislikedNames.length > 0) {
                     const dislikedValues = dislikedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
-                    await manager.query(`INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES ${dislikedValues}`);
+                    await transactionalEntityManager.query(`INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES ${dislikedValues}`);
                 }
             }
         );
-    }    
+    },
+    signup(parent: Parent, user: User, address: Address) {
+        return parentRepo.manager.transaction(
+            'SERIALIZABLE',
+            async (manager) => {
+                await manager.save(address);
+                await manager.save(parent);
+                await manager.save(user);
+            }
+        );
+    }
 });

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -16,7 +16,7 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
     findAll() {
         return parentRepo.find({
             relations: {
-                names: true,
+                likedNames: true,
                 families: true,
                 address: true,
             }

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -30,7 +30,6 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
                     const likedValues = likedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
                     await manager.query(`INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES ${likedValues}`);
                 }
-    
                 if (dislikedNames.length > 0) {
                     const dislikedValues = dislikedNames.map(nameSuggestId => `(${parentId}, ${nameSuggestId})`).join(', ');
                     await manager.query(`INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES ${dislikedValues}`);

--- a/src/Repositories/parentRepository.ts
+++ b/src/Repositories/parentRepository.ts
@@ -21,5 +21,24 @@ export const parentRepo = appDataSource.getRepository(Parent).extend({
                 address: true,
             }
         });
+    },
+    updateTablesForName(parentId: number, likedNames: number[], dislikedNames: number[]) {
+        return parentRepo.manager.transaction(
+            'SERIALIZABLE',
+            async (manager) => {
+                await Promise.all(likedNames.map(async (nameSuggestId) => {
+                    await manager.query('INSERT INTO parent_name_suggest (fk_parent_id, fk_name_suggest_id) VALUES (?, ?)', [
+                        parentId,
+                        nameSuggestId,
+                    ]);
+                }));
+                await Promise.all(dislikedNames.map(async (nameSuggestId) => {
+                    await manager.query('INSERT INTO parent_name_suggest_dislike (fk_parent_id, fk_name_suggest_id) VALUES (?, ?)', [
+                        parentId,
+                        nameSuggestId,
+                    ]);
+                }));
+            }
+        );
     }
 });

--- a/src/Repositories/roleRepository.ts
+++ b/src/Repositories/roleRepository.ts
@@ -6,17 +6,15 @@ export const roleRepo = appDataSource.getRepository(Role).extend({
         return roleRepo.find({
             select: {
                 roleId: true,
-                title: true,
-                users: true
+                title: true
             },
             relations: {
                 users: true
             },
         });
-    },findOneByID(id: number) {
+    },
+    findOneByID(id: number) {
         return roleRepo.findOne({
-            relations: {
-            },
             where: {
                 roleId: id
             }

--- a/src/Repositories/userRepository.ts
+++ b/src/Repositories/userRepository.ts
@@ -49,7 +49,7 @@ export const userRepo = appDataSource.getRepository(User).extend({
       params
     );
   },
-  // transaction
+  // TODO: Code something useful here
   updateTablesForName(name: string) {
     return userRepo.manager.transaction(
       'SERIALIZABLE',

--- a/src/Repositories/userRepository.ts
+++ b/src/Repositories/userRepository.ts
@@ -49,8 +49,8 @@ export const userRepo = appDataSource.getRepository(User).extend({
       params
     );
   },
-  // TODO: Code something useful here
-  updateTablesForName(name: string) {
+  // TODO: update this to use the new stored procedure
+  updateTablesForName(id: number) {
     return userRepo.manager.transaction(
       'SERIALIZABLE',
       async (manager) => {

--- a/src/Repositories/userRepository.ts
+++ b/src/Repositories/userRepository.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable no-unused-vars */
-import { UserRequestDTO } from '../DTO/userDTO';
 import { User } from '../Entities/User';
 import { appDataSource } from './data-source';
 
@@ -49,20 +46,4 @@ export const userRepo = appDataSource.getRepository(User).extend({
       params
     );
   },
-  // TODO: update this to use the new stored procedure
-  updateTablesForName(id: number) {
-    return userRepo.manager.transaction(
-      'SERIALIZABLE',
-      async (manager) => {
-      await manager.query('update user set name = ? where name = ?', [
-        name,
-        name,
-      ]);
-      await manager.query('update parent set name = ? where name = ?', [
-        name,
-        name,
-      ]);
-    });
-  },
 });
-

--- a/src/Repositories/userRepository.ts
+++ b/src/Repositories/userRepository.ts
@@ -1,5 +1,8 @@
+import { Address } from '../Entities/Address';
+import { Parent } from '../Entities/Parent';
 import { User } from '../Entities/User';
 import { appDataSource } from './data-source';
+import { parentRepo } from './parentRepository';
 
 export const userRepo = appDataSource.getRepository(User).extend({
   findOneByID(id: number) {
@@ -46,4 +49,14 @@ export const userRepo = appDataSource.getRepository(User).extend({
       params
     );
   },
+  signUpTransaction(parent: Parent, user: User, address: Address) {
+    return parentRepo.manager.transaction(
+      'SERIALIZABLE',
+      async (manager) => {
+        await manager.save(address);
+        await manager.save(parent);
+        await manager.save(user);
+      }
+    );
+  }
 });

--- a/src/Repositories/userRepository.ts
+++ b/src/Repositories/userRepository.ts
@@ -49,4 +49,20 @@ export const userRepo = appDataSource.getRepository(User).extend({
       params
     );
   },
+  // transaction
+  updateTablesForName(name: string) {
+    return userRepo.manager.transaction(
+      'SERIALIZABLE',
+      async (manager) => {
+      await manager.query('update user set name = ? where name = ?', [
+        name,
+        name,
+      ]);
+      await manager.query('update parent set name = ? where name = ?', [
+        name,
+        name,
+      ]);
+    });
+  },
 });
+

--- a/src/Services/nameService.ts
+++ b/src/Services/nameService.ts
@@ -50,7 +50,7 @@ export const getNamesByParentId = async (parentId: number, isLiked: string) => {
     } else {
       return failed('isLiked');
     }
-    
+
     const nameDTOs: NameResponseDTO[] = RemoveDublicates(response);
 
     return success(nameDTOs);
@@ -61,12 +61,12 @@ export const getNamesByParentId = async (parentId: number, isLiked: string) => {
 
 export const getParentlessNames = async (parentId: number) => {
   try {
-  const response = await nameRepo.findParentlessNames(parentId);
-  const nameDTOs: NameResponseDTO[] = RemoveDublicates(response);
-  return success(nameDTOs);
-} catch (err) {
-  return failed(err);
-}
+    const response = await nameRepo.findParentlessNames(parentId);
+    const nameDTOs: NameResponseDTO[] = RemoveDublicates(response);
+    return success(nameDTOs);
+  } catch (err) {
+    return failed(err);
+  }
 };
 
 export const updateName = async (nameRequestDTO: NameRequestDTO) => {

--- a/src/Services/nameService.ts
+++ b/src/Services/nameService.ts
@@ -29,6 +29,19 @@ export const getNameByID = async (id: number) => {
   }
 };
 
+export const getNameByNameSuggestName = async (name: string) => {
+try {
+  const response = await nameRepo.findOneByName(name);
+  if(!response){
+    return failed(new Error('No such name'));
+  }
+
+   return success(convertToDTO(response));
+  } catch (err) {
+    return failed(err);
+  }
+};
+
 export const getNames = async () => {
   try {
     const names = await nameRepo.findAll();

--- a/src/Services/nameService.ts
+++ b/src/Services/nameService.ts
@@ -45,8 +45,10 @@ export const getNamesByParentId = async (parentId: number, isLiked: string) => {
     let response;
     if (isLiked === 'true') {
       response = await nameRepo.findNamesByParentId(parentId);
-    } else (isLiked === 'false'); {
+    } else if (isLiked === 'false') {
       response = await nameRepo.findDislikedNamesByParentId(parentId);
+    } else {
+      return failed('isLiked');
     }
     
     const nameDTOs: NameResponseDTO[] = RemoveDublicates(response);

--- a/src/Services/parentService.ts
+++ b/src/Services/parentService.ts
@@ -62,6 +62,25 @@ export const deleteParent = async (parentId: number) => {
   }
 };
 
+export const updateTablesForName = async (
+  parentId: number,
+  likedNames: number[],
+  dislikedNames: number[]
+) => {
+  try {
+    await parentRepo.updateTablesForName(
+      parentId,
+      likedNames,
+      dislikedNames
+    );
+    
+    return success('Updated tables for name');
+
+  } catch (err) {
+    return failed(err);
+  }
+};
+
 export const convertToDTO = (parent: Parent) => {
   const dto: ParentResponseDTO = {
     parentId: parent.parentId,

--- a/src/Services/parentService.ts
+++ b/src/Services/parentService.ts
@@ -68,7 +68,7 @@ export const convertToDTO = (parent: Parent) => {
     gender: parent.gender,
     firstName: parent.firstName,
     lastName: parent.lastName,
-    names: parent.names as NameResponseDTO[],
+    likedNames: parent.names as NameResponseDTO[],
     families: parent.families,
     address: parent.address,
   };

--- a/src/Services/parentService.ts
+++ b/src/Services/parentService.ts
@@ -68,7 +68,7 @@ export const convertToDTO = (parent: Parent) => {
     gender: parent.gender,
     firstName: parent.firstName,
     lastName: parent.lastName,
-    likedNames: parent.names as NameResponseDTO[],
+    likedNames: parent.likedNames as NameResponseDTO[],
     families: parent.families,
     address: parent.address,
   };

--- a/src/Services/parentService.ts
+++ b/src/Services/parentService.ts
@@ -40,7 +40,8 @@ export const getParentById = async (id: number) => {
 
 export const updateParent = async (parentDTO: ParentRequestDTO) => {
   try {
-    const response = await parentRepo.save(parentDTO);
+    const response = await parentRepo.save(parentDTO as Parent);
+    
     return success(convertToDTO(response));
   } catch (err) {
     return failed(err);
@@ -69,6 +70,7 @@ export const convertToDTO = (parent: Parent) => {
     firstName: parent.firstName,
     lastName: parent.lastName,
     likedNames: parent.likedNames as NameResponseDTO[],
+    dislikedNames: parent.dislikedNames as NameResponseDTO[],
     families: parent.families,
     address: parent.address,
   };

--- a/src/Services/parentService.ts
+++ b/src/Services/parentService.ts
@@ -41,7 +41,7 @@ export const getParentById = async (id: number) => {
 export const updateParent = async (parentDTO: ParentRequestDTO) => {
   try {
     const response = await parentRepo.save(parentDTO as Parent);
-    
+
     return success(convertToDTO(response));
   } catch (err) {
     return failed(err);
@@ -68,13 +68,13 @@ export const updateTablesForName = async (
   dislikedNames: number[]
 ) => {
   try {
-    await parentRepo.updateTablesForName(
+    await parentRepo.saveLikedDislikedNames(
       parentId,
       likedNames,
       dislikedNames
     );
-    
-    return success('Updated tables for name');
+
+    return success(`Updated liked and disliked names for parent with id ${parentId}`);
 
   } catch (err) {
     return failed(err);

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -70,16 +70,15 @@ export const getParentByEmailAndPassword = async (
   res: Response
 ) => {
   try {
-    const response = await userRepo.findOneByEmail(userLogin.email);
+    const response = await userRepo.findOneByEmail(userLogin.email);  
 
     if (!response) {
       return failed(new Error('Email or password is incorrect'));
     }
-
     const isPasswordCorrect = await comparePassword(
       userLogin.password,
       response.password
-    );
+    );  
 
     if (!isPasswordCorrect) {
       return failed(new Error('Email or password is incorrect'));
@@ -122,7 +121,7 @@ export const getParentByEmailAndPassword = async (
     user.parent!.address = address;
 
     const token = await authService.login(response, res);
-
+  
     return success({ user: user, token });
   } catch (err) {
     return failed(err);

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -10,6 +10,8 @@ import { parentRepo } from '../Repositories/parentRepository';
 import { ParentResponseDTO } from '../DTO/parentDTO';
 import { addressRepo } from '../Repositories/addressRepository';
 import { AddressResponseDTO } from '../DTO/addressDTO';
+import * as nameService from './nameService';
+import { NameResponseDTO } from '../DTO/nameDTO';
 
 export const createUser = async (UserRequestDTO: UserRequestDTO) => {
   try {
@@ -74,12 +76,12 @@ export const getParentByEmailAndPassword = async (
       return failed(new Error('Email or password is incorrect'));
     }
 
-    const isPsswordCorrect = await comparePassword(
+    const isPasswordCorrect = await comparePassword(
       userLogin.password,
       response.password
     );
 
-    if (!isPsswordCorrect) {
+    if (!isPasswordCorrect) {
       return failed(new Error('Email or password is incorrect'));
     }
 
@@ -90,10 +92,25 @@ export const getParentByEmailAndPassword = async (
       return failed(new Error('No Parent'));
     }
 
+    if (parent.names) {
+      const likedNames = await nameService.getNamesByParentId(parent.parentId!, 'true');
+
+      if (likedNames.success) {
+        parent.names = likedNames.result.data as NameResponseDTO[];
+      }
+
+      const dislikedNames = await nameService.getNamesByParentId(parent.parentId!, 'false');
+
+      if (dislikedNames.success) {
+        parent.dislikedNames = dislikedNames.result.data as NameResponseDTO[];
+      }
+    }
+
     const user: UserResponseDTO = {
       email: response.email,
       roles: response.roles,
       parent: parent,
+
       userActive: false
     };
 

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -92,7 +92,7 @@ export const getParentByEmailAndPassword = async (
       return failed(new Error('No Parent'));
     }
 
-    if (parent.names) {
+    if (!parent.names) {
       const likedNames = await nameService.getNamesByParentId(parent.parentId!, 'true');
 
       if (likedNames.success) {

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -130,12 +130,12 @@ export const updateUser = async (userDTO: UserRequestDTO, email: string) => {
       return failed(new Error('Email or password is incorrect'));
     }
 
-    const isPsswordCorrect = await comparePassword(
+    const isPasswordCorrect = await comparePassword(
       userDTO.password,
       response.password
     );
 
-    if (!isPsswordCorrect) {
+    if (!isPasswordCorrect) {
       return failed(new Error('Email or password is incorrect'));
     }
 

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -92,11 +92,11 @@ export const getParentByEmailAndPassword = async (
       return failed(new Error('No Parent'));
     }
 
-    if (!parent.names) {
+    if (!parent.likedNames) {
       const likedNames = await nameService.getNamesByParentId(parent.parentId!, 'true');
 
       if (likedNames.success) {
-        parent.names = likedNames.result.data as NameResponseDTO[];
+        parent.likedNames = likedNames.result.data as NameResponseDTO[];
       }
 
       const dislikedNames = await nameService.getNamesByParentId(parent.parentId!, 'false');

--- a/src/routes/nameRoute.ts
+++ b/src/routes/nameRoute.ts
@@ -4,11 +4,12 @@ import { validateDate, validateParamsId } from '../Utils/routeUtil';
 
 const nameRouter = Router();
 
-nameRouter.post('/names', validateDate, nameController.createName);
-nameRouter.get('/names/:id', validateParamsId, nameController.getNameByID);
 nameRouter.get('/names', nameController.getAllNames);
+nameRouter.get('/names/name=:name', nameController.getNameByNameSuggestName);
+nameRouter.get('/names/:id', validateParamsId, nameController.getNameByID);
 nameRouter.get('/names/parent/:id/:isliked', validateParamsId, nameController.getNamesByParentId);
 nameRouter.get('/names/parent/:id', validateParamsId, nameController.getParentlessNames);
+nameRouter.post('/names', validateDate, nameController.createName);
 nameRouter.put('/names', validateDate, nameController.updateName);
 nameRouter.put('/names/:id', validateParamsId, nameController.deleteNameByID);
 

--- a/src/routes/parentRoute.ts
+++ b/src/routes/parentRoute.ts
@@ -9,5 +9,6 @@ parentRouter.get('/parents', parentController.getAllParents);
 parentRouter.get('/parents/:id', validateParamsId, parentController.getParentById);
 parentRouter.put('/parents', parentController.updateParent);
 parentRouter.put('/parents/:id', validateParamsId, parentController.deleteParent);
+parentRouter.put('/parents/:id/tables', parentController.updateTablesForName);
 
 export default parentRouter;


### PR DESCRIPTION
- Added work around for audit tables foreign key issue. This removes the values of the unique columns of the foreign keys in the audit tables. This is used when working in a dev "synchronized = true" environment. In production synchronized = false, we can 
```
ALTER TABLE adt_user
    DROP COLUMN fk_parent_id;

ALTER TABLE adt_user
    ADD COLUMN fk_parent_id INT;
```
To get rid of the unique constraint - and keep the foreign key values.

- Added transaction for updating liked and disliked names for a given user.
- Added index for names
- Cleanup